### PR TITLE
fix: add @RegisterForReflection annotation to run native images

### DIFF
--- a/reply-core/src/main/java/org/stll/reply/core/dtos/CreateMessageRequest.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/CreateMessageRequest.java
@@ -1,9 +1,11 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@RegisterForReflection
 @Schema(
         example = "{\"message\": \"texto\"}"
 )

--- a/reply-core/src/main/java/org/stll/reply/core/dtos/CreateTicketRequest.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/CreateTicketRequest.java
@@ -1,7 +1,9 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@RegisterForReflection
 @Schema(
         example = "{\"subject\": \"Assunto do novo ticket\"}"
 )

--- a/reply-core/src/main/java/org/stll/reply/core/dtos/LoginRequest.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/LoginRequest.java
@@ -1,5 +1,6 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -10,6 +11,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@RegisterForReflection
 @Schema(
         example = "{\"username\": \"aaa\", \"password\": \"Senha2#?\"}"
 )

--- a/reply-core/src/main/java/org/stll/reply/core/dtos/LoginResponse.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/LoginResponse.java
@@ -1,5 +1,6 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@RegisterForReflection
 public class LoginResponse {
     public boolean success;
     public String message;

--- a/reply-core/src/main/java/org/stll/reply/core/dtos/PaginationResponse.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/PaginationResponse.java
@@ -1,5 +1,6 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@RegisterForReflection
 public class PaginationResponse<T> {
     private List<T> data;
     private int currentPage;

--- a/reply-core/src/main/java/org/stll/reply/core/dtos/RegistrationRequest.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/RegistrationRequest.java
@@ -1,5 +1,6 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -11,6 +12,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@RegisterForReflection
 @Schema(
         example = "{\"username\": \"aaa\", \"email\": \"aaa@email.com\", \"password\": \"Senha2#?\"}"
 )

--- a/reply-core/src/main/java/org/stll/reply/core/dtos/RoleUpdateRequest.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/RoleUpdateRequest.java
@@ -1,5 +1,6 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@RegisterForReflection
 public class RoleUpdateRequest {
     private List<String> roleNames;
 }

--- a/reply-core/src/main/java/org/stll/reply/core/dtos/SaveMessageRequest.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/SaveMessageRequest.java
@@ -1,9 +1,11 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.util.UUID;
 
+@RegisterForReflection
 @Schema(
         example = "{\"subject\": \"Assunto do novo ticket\", \"userId\": \"0123\"}"
 )

--- a/reply-core/src/main/java/org/stll/reply/core/dtos/SaveTicketRequest.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/SaveTicketRequest.java
@@ -1,9 +1,11 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.util.UUID;
 
+@RegisterForReflection
 @Schema(
         example = "{\"subject\": \"Assunto do novo ticket\", \"userId\": \"0123\"}"
 )

--- a/reply-core/src/main/java/org/stll/reply/core/dtos/SaveTicketResponse.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/SaveTicketResponse.java
@@ -1,5 +1,6 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
@@ -7,6 +8,7 @@ import java.util.UUID;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@RegisterForReflection
 public class SaveTicketResponse {
     public String subject;
     public UUID ticketId;

--- a/reply-core/src/main/java/org/stll/reply/core/dtos/ValidationResponse.java
+++ b/reply-core/src/main/java/org/stll/reply/core/dtos/ValidationResponse.java
@@ -1,5 +1,6 @@
 package org.stll.reply.core.dtos;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import java.util.UUID;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@RegisterForReflection
 public class ValidationResponse {
     private UUID userId;
     private Set<String> roles;


### PR DESCRIPTION
---
name: Pull Request
about: Add required annotations to run the application from native images.
title: ''
labels: fix
assignees: ''

---


**What's Changed?**
Added @RegisterForReflection annotation to dtos. Reflection is a feature of the Java programming language that enables a running Java program to examine and modify attributes of its classes, interfaces, fields, and methods.

> The native-image utility provides partial support for reflection. 

[Reference - GraalVM](https://www.graalvm.org/22.2/reference-manual/native-image/guides/build-with-reflection/)

> When building a native executable, GraalVM operates with a closed world assumption. It analyzes the call tree and removes all the classes/methods/fields that are not used directly.

[Reference - Quarkus](https://pt.quarkus.io/guides/writing-native-applications-tips)


Link to the issue it fixes: # (issue number) 

**Type of Change**
[x] Bug fix
[ ] New feature
[ ] Other (please explain): 

**How to Test This**
Explain how someone can test your changes.
